### PR TITLE
test/e2e: Support configuring ExtraPortMappings for the kind cluster 

### DIFF
--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -82,6 +82,13 @@ func WithDualStackFamily() KindClusterOption {
 	})
 }
 
+// WithExtraPortMappings implements a New Option that instruct the kindClusterProvider to set extra port forward mappings.
+func WithExtraPortMappings(mappings []kindv1.PortMapping) KindClusterOption {
+	return kindClusterOptionAdapter(func(k *KindClusterProvider) {
+		k.extraPortMappings = mappings
+	})
+}
+
 // LogFolder implements a New Option that instruct the kindClusterProvider to dump bootstrap logs in a folder in case of errors.
 func LogFolder(path string) KindClusterOption {
 	return kindClusterOptionAdapter(func(k *KindClusterProvider) {
@@ -104,12 +111,13 @@ func NewKindClusterProvider(name string, options ...KindClusterOption) *KindClus
 
 // KindClusterProvider implements a ClusterProvider that can create a kind cluster.
 type KindClusterProvider struct {
-	name           string
-	withDockerSock bool
-	kubeconfigPath string
-	nodeImage      string
-	ipFamily       clusterv1.ClusterIPFamily
-	logFolder      string
+	name              string
+	withDockerSock    bool
+	kubeconfigPath    string
+	nodeImage         string
+	ipFamily          clusterv1.ClusterIPFamily
+	logFolder         string
+	extraPortMappings []kindv1.PortMapping
 }
 
 // Create a Kubernetes cluster using kind.
@@ -138,6 +146,11 @@ func (k *KindClusterProvider) createKindCluster() {
 		TypeMeta: kindv1.TypeMeta{
 			APIVersion: "kind.x-k8s.io/v1alpha4",
 			Kind:       "Cluster",
+		},
+		Nodes: []kindv1.Node{
+			{
+				ExtraPortMappings: k.extraPortMappings,
+			},
 		},
 	}
 

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	kind "sigs.k8s.io/kind/pkg/cluster"
 	kindnodes "sigs.k8s.io/kind/pkg/cluster/nodes"
 	kindnodesutils "sigs.k8s.io/kind/pkg/cluster/nodeutils"
@@ -52,6 +53,9 @@ type CreateKindBootstrapClusterAndLoadImagesInput struct {
 
 	// LogFolder where to dump logs in case of errors
 	LogFolder string
+
+	// ExtraPortMappings specifies the port forward configuration of the kind node.
+	ExtraPortMappings []kindv1.PortMapping
 }
 
 // CreateKindBootstrapClusterAndLoadImages returns a new Kubernetes cluster with pre-loaded images.
@@ -77,6 +81,7 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	if input.LogFolder != "" {
 		options = append(options, LogFolder(input.LogFolder))
 	}
+	options = append(options, WithExtraPortMappings(input.ExtraPortMappings))
 
 	clusterProvider := NewKindClusterProvider(input.Name, options...)
 	Expect(clusterProvider).ToNot(BeNil(), "Failed to create a kind cluster")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Support configuring ExtraPortMappings for the kind cluster created in e2e test. So the workload cluster nodes can access the service exposed via NodePort in the kind cluster. Refer to https://kind.sigs.k8s.io/docs/user/configuration/#nodeport-with-port-mappings.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->